### PR TITLE
Bump Specter version to 0.11.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [potemkin "0.4.3" :exclusions [org.clojure/clojure]]
-                 [com.rpl/specter "0.9.2" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
+                 [com.rpl/specter "0.11.0" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
                  [environ "1.0.2" :exclusions [org.clojure/clojure]]
                  [commons-codec/commons-codec "1.10"]]
 

--- a/src/such/readable.clj
+++ b/src/such/readable.clj
@@ -7,7 +7,9 @@
             [such.types :as type]
             [clojure.string :as str]
             [clojure.repl :as repl]
-            [com.rpl.specter :as specter]))
+            [com.rpl.specter :as specter]
+            [com.rpl.specter.macros :refer [transform]]
+            ))
 
 ;;; What is stringified is controlled by two dynamically-bound variables.
 
@@ -169,15 +171,15 @@
   "`str` applied to the result of [[fn-symbol]]."
   [f]
   (str (fn-symbol f)))
-  
+
 
 (defn- better-aliases [x aliases]
-  (specter/transform (specter/walker translatable?)
+  (transform (specter/walker translatable?)
                      translate
                      x))
 
 (defn- better-function-names [x anonymous-names]
-  (specter/transform (specter/walker type/extended-fn?)
+  (transform (specter/walker type/extended-fn?)
                      #(elaborate-fn-symbol % *function-elaborations* anonymous-names)
                      x))
 

--- a/src/such/readable.clj
+++ b/src/such/readable.clj
@@ -8,8 +8,7 @@
             [clojure.string :as str]
             [clojure.repl :as repl]
             [com.rpl.specter :as specter]
-            [com.rpl.specter.macros :refer [transform]]
-            ))
+            [com.rpl.specter.macros :refer [transform]]))
 
 ;;; What is stringified is controlled by two dynamically-bound variables.
 


### PR DESCRIPTION
Latest version of Specter moved translate into `com.rpl.specter.macros` namespace. As a end result the latest version Midje is not usable with Specter side by side. I left the version bump to your decision. Once this PR is approved, the next step would be also bump the Midje suchwow dependency. 

For reference https://github.com/nathanmarz/specter/issues/112 

All `lein compatibility` tests succeeded. 
