### PR TITLE
Bump specter version to fix warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: clojure
-lein: lein2
+lein: lein
 script: lein travis
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [6.0.1] - 2017-11-1
+- Upgrade to Specter 1.0.4 to avoid `any? in com.rpl.specter.impl` warning
+
 ## [6.0.0] - 2016-10-26
 - Upgrade to Specter 0.13
 - ... which caused Clojure 1.6 to be abandoned, so major version bump.

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :url "http://unlicense.org/"
             :distribution :repo}
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [potemkin "0.4.3" :exclusions [org.clojure/clojure]]
                  [com.rpl/specter "1.0.4" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
                  [environ "1.1.0" :exclusions [org.clojure/clojure]]
@@ -15,7 +15,7 @@
   :repl-options {:init (do (require 'such.doc)
                            (such.doc/apis))}
 
-  :profiles {:dev {:dependencies [[midje "1.9.0-alpha9" :exclusions [org.clojure/clojure]]
+  :profiles {:dev {:dependencies [[midje "1.9.0" :exclusions [org.clojure/clojure]]
                                   [org.clojure/math.combinatorics "0.1.3"]
                                   [org.clojure/data.json "0.2.6"]
                                   ;; Including compojure so that `lein ancient` will
@@ -26,7 +26,7 @@
                                   [compojure "1.5.1" :exclusions [org.clojure/clojure]]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-beta4"]]}}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}}
 
   :plugins [[lein-midje "3.2.1"]
             [codox "0.8.11"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject marick/suchwow "6.0.0"
+(defproject marick/suchwow "6.0.1"
   :description "Such functions! Such doc strings! Much utility!"
   :url "https://github.com/marick/suchwow"
   :pedantic? :warn
@@ -8,14 +8,14 @@
 
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [potemkin "0.4.3" :exclusions [org.clojure/clojure]]
-                 [com.rpl/specter "0.13.0" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
+                 [com.rpl/specter "1.0.4" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
                  [environ "1.1.0" :exclusions [org.clojure/clojure]]
                  [commons-codec/commons-codec "1.10"]]
 
   :repl-options {:init (do (require 'such.doc)
                            (such.doc/apis))}
 
-  :profiles {:dev {:dependencies [[midje "1.9.0-alpha6" :exclusions [org.clojure/clojure]]
+  :profiles {:dev {:dependencies [[midje "1.9.0-alpha9" :exclusions [org.clojure/clojure]]
                                   [org.clojure/math.combinatorics "0.1.3"]
                                   [org.clojure/data.json "0.2.6"]
                                   ;; Including compojure so that `lein ancient` will
@@ -26,8 +26,7 @@
                                   [compojure "1.5.1" :exclusions [org.clojure/clojure]]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha13"]]}
-             }
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-beta4"]]}}
 
   :plugins [[lein-midje "3.2.1"]
             [codox "0.8.11"]]
@@ -42,5 +41,4 @@
 
   ;; For Clojure snapshots
   :repositories {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
-  :deploy-repositories [["releases" :clojars]]
-)
+  :deploy-repositories [["releases" :clojars]])


### PR DESCRIPTION
If you run Midje with `clojure-1.9-beta4` you will see the following warning

```
WARNING: any? already refers to: #'clojure.core/any? in namespace: com.rpl.specter.impl, being replaced by: #'com.rpl.specter.impl/any?
```

This comes from `specter`, imported by `suchwow`, and was fixed in [`0.13.1`](https://github.com/nathanmarz/specter/blob/master/CHANGES.md#0131). 